### PR TITLE
Index of keywords

### DIFF
--- a/atlas.tex
+++ b/atlas.tex
@@ -38,4 +38,7 @@
 % List of Figures
 \listoffigures
 
+% Index
+\printindex
+
 \end{document}

--- a/example-istqb-content.md
+++ b/example-istqb-content.md
@@ -66,6 +66,9 @@ You can reference the table from the text of the document as follows: <#table:la
 
 Here are example citations for standards [@iso-iec:2022], ISTQB documents [@istqb:2023], books [@beizer:1990], journal articles [@brykczynski:1992], and web pages [@marick:2013]. For instructions on writing your own references to `example.bib`, see the Bib\LaTeX{} manual [@kime:2023, Chapter 2]. The full list of references is shown at the end of this document.
 
+### Indexing
+
+To index a term, write `[term]{.index}`. For example, [0-switch coverage]{.index}, [component integration testing]{.index}, or [functional appropriateness]{.index}. All indexed terms are shown at the end of this document.
 
 ## What is Testing?
 

--- a/example.tex
+++ b/example.tex
@@ -54,4 +54,7 @@
 % List of Figures
 \listoffigures
 
+% Index
+\printindex
+
 \end{document}

--- a/istqb.cls
+++ b/istqb.cls
@@ -88,8 +88,6 @@
 \RequirePackage{xcolor}
 \RequirePackage{mdframed}
 \RequirePackage{lastpage}
-\PassOptionsToPackage{hidelinks}{hyperref}
-\RequirePackage{hyperref}
 \ExplSyntaxOn
 \str_new:N \g_istqb_version_str
 \str_gset:Nn
@@ -298,3 +296,16 @@
   \setcounter{istqbsubobjective}{0}%
   \par\kern -0.2in
 }
+
+% Index
+\RequirePackage{imakeidx}
+\makeindex[columns=2, columnsep=1cm, noautomatic]
+% Ensure that the index is numbered and part of the table of contents.
+\renewcommand\imki@indexlevel{\section}
+% Remove spaces between indexed items.
+\RequirePackage{etoolbox}
+\apptocmd\theindex{\let\indexspace=\relax}{}{\PatchFailed}
+
+% Hyperlinks
+\PassOptionsToPackage{hidelinks}{hyperref}
+\RequirePackage{hyperref}

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -312,3 +312,36 @@
   {
     citations,
   }
+
+% Index
+\markdownSetup
+  {
+    bracketedSpans,
+    rendererPrototypes = {
+      bracketedSpanAttributeContextBegin = {
+        \group_begin:
+        \markdownSetup
+          {
+            rendererPrototypes = {
+              attributeClassName = {
+                \str_if_eq:nnT
+                  { ##1 }
+                  { index }
+                  {
+                    \def\next####1\markdownRendererBracketedSpanAttributeContextEnd
+                      {
+                        \global\index { ####1 }
+                        ####1
+                        \markdownRendererBracketedSpanAttributeContextEnd
+                      }
+                    \next
+                  }
+              },
+            }
+          }
+      },
+      bracketedSpanAttributeContextEnd = {
+        \group_end:
+      },
+    }
+  }


### PR DESCRIPTION
Closes #16.

Here is an example of indexing from `example-istqb-content.md`:

``` md
### Indexing

To index a term, write `[term]{.index}`. For example, [0-switch coverage]{.index},
[component integration testing]{.index}, or [functional appropriateness]{.index}.
All indexed terms are shown at the end of this document.
```

Here is the PDF output of the example:

![image](https://github.com/danopolan/istqb_latex/assets/603082/1b92b60f-af0b-42ce-98b8-0348dd5ecd88)

Here is the index generated at the end of the document:

![image](https://github.com/danopolan/istqb_latex/assets/603082/e7ea1d13-9f04-4de4-bc0f-6692d429a773)