### PR TITLE
Ensure correct encoding of input files

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -9,6 +9,12 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v3
+      - name: Ensure correct encoding of input files
+        run: |
+          set -ex
+          apt -qy update
+          apt -qy install --no-install-recommends dos2unix
+          find -type f \( -name '*.md' -o -name '*.yml' \) -exec dos2unix {} +
       - name: Compile LaTeX document example.tex
         run: latexmk -shell-escape -pdf example.tex
       - name: Compile LaTeX document atlas.tex


### PR DESCRIPTION
Fixes point 1 in https://github.com/danopolan/istqb_latex/issues/34 by ensuring that all markdown and YAML documents are correctly encoded before typesetting. After merging this PR into branch main, you should also merge branch main into branch atlas-release.