### PR TITLE
Enable hashEnumerator option in atlas.tex

### DIFF
--- a/example-istqb-content.md
+++ b/example-istqb-content.md
@@ -129,19 +129,19 @@ cause analysis is discussed in ISTQB-CTEL-TM and ISTQB-CTEL-ITP.
 
 A number of testing principles have been suggested over the past 50 years and offer general guidelines common for all testing.  
   
-#. **Testing shows the presence of defects, not their absence**  
+#. **Testing shows the presence of defects, not their absence:**
   Testing can show that defects are present, but cannot prove that there are no defects. Testing reduces the probability of undiscovered defects remaining in the software but, even if no defects are found, testing is not a proof of correctness.  
-#. **Exhaustive testing is impossible**  
+#. **Exhaustive testing is impossible:**
   Testing everything (all combinations of inputs and preconditions) is not feasible except for trivial cases. Rather than attempting to test exhaustively, risk analysis, test techniques, and priorities should be used to focus test efforts.  
-#. **Early testing saves time and money**  
+#. **Early testing saves time and money:**
   To find defects early, both static and dynamic test activities should be started as early as possible in the software development lifecycle. Early testing is sometimes referred to as shift left. Testing early in the software development lifecycle helps reduce or eliminate costly changes (see section 3.1).  
-#. **Defects cluster together**  
+#. **Defects cluster together:**
   A small number of modules usually contains most of the defects discovered during pre-release testing, or is responsible for most of the operational failures. Predicted defect clusters, and the actual observed defect clusters in test or operation, are an important input into a risk analysis used to focus the test effort (as mentioned in principle 2).  
-#. **Beware of the pesticide paradox**  
+#. **Beware of the pesticide paradox:**
   If the same tests are repeated over and over again, eventually these tests no longer find any new defects. To detect new defects, existing tests and test data may need changing, and new tests may need to be written. (Tests are no longer effective at finding defects, just as pesticides are no longer effective at killing insects after a while.) In some cases, such as automated regression testing, the pesticide paradox has a beneficial outcome, which is the relatively low number of regression defects.  
-#. **Testing is context dependent**  
+#. **Testing is context dependent:**
   Testing is done differently in different contexts. For example, safety-critical industrial control software is tested differently from an e-commerce mobile app. As another example, testing in an Agile project is done differently than testing in a sequential software development lifecycle project (see section 2.1).  
-#. **Absence-of-errors is a fallacy**  
+#. **Absence-of-errors is a fallacy:**
   Some organizations expect that testers can run all possible tests and find all possible defects, but principles 2 and 1, respectively, tell us that this is impossible. Further, it is a fallacy (i.e., a mistaken belief) to expect that just finding and fixing a large number of defects will ensure the success of a system. For example, thoroughly testing all specified requirements and fixing all defects found could still produce a system that is difficult to use, that does not fulfill the users’ needs and expectations, or that is inferior compared to other competing systems.  
   
 See Myers 2011, Kaner 2002, Weinberg 2008, and Beizer 1990 for examples of these and other testing principles. 

--- a/example.tex
+++ b/example.tex
@@ -1,34 +1,6 @@
 \documentclass{istqb}
-
-\usepackage[
-  import=istqb/syllabus,
-  definitionLists,
-  fencedCode,
-  hashEnumerators,
-  hybrid,
-  inlineFootnotes,
-  rawAttribute,
-  smartEllipses,
-  texMathDollars,
-]{markdown}
-\usepackage{lipsum}
-\usepackage{titlesec}
-\usepackage{enumitem}
-
-% % You can re-define how links are rendered: uncomment the following to get hyperlinked text instead of footnotes
-% %%begin novalidate
-% \markdownSetup{rendererPrototypes={
-%   link = {\href{#2}{#1}},
-%   image = {\begin{figure}[hbt!]
-%     \centering
-%     \includegraphics{#3}%
-%     \ifx\empty#4\empty\else
-%     \caption{#4}%
-%     \fi
-%     \label{fig:#1}%
-%     \end{figure}}
-% }}
-% %%end novalidate
+\usepackage[import=istqb/syllabus]{markdown}
+\markdownSetup{hybrid}  % Enable hybrid Markdown + LaTeX markup
 
 % Metadata
 \markdownInput[snippet=istqb/syllabus/metadata]{./example.yml}

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -5,6 +5,16 @@
   {0.0.1}%
   {LaTeX theme for the Markdown Package that typesets ISTQB Syllabi}
 
+% Hybrid Markdown + LaTeX text
+\markdownSetup{
+  rawAttribute,
+}
+
+% Lists
+\markdownSetup{
+  hashEnumerators,
+}
+
 % Metadata
 \str_new:N \g_istqb_title_str
 \str_new:N \g_istqb_code_str


### PR DESCRIPTION
Fixes points 3 and 4 in https://github.com/danopolan/istqb_latex/issues/34 by enabling the [hashEnumerator](https://witiko.github.io/markdown/#option-hashenumerators) syntax extension in atlas.tex. After merging this PR into branch main, you should also merge branch main into branch atlas-release.