### PR TITLE
Include references that are not cited in the text

### DIFF
--- a/atlas.tex
+++ b/atlas.tex
@@ -30,6 +30,7 @@
 \markdownInput{md/09-glossary.md}
 
 % Bibliography
+\nocite{*}  % Include references that are not cited in the text
 \printistqbbibliography
 
 % List of Tables

--- a/example.tex
+++ b/example.tex
@@ -46,6 +46,7 @@
 \markdownInput{./example-istqb-content.md}
 
 % Bibliography
+\nocite{*}  % Include references that are not cited in the text
 \printistqbbibliography
 
 % List of Tables


### PR DESCRIPTION
Fixes point 5 from #34 and closes #34 by ensuring that all references in the .bib file(s) with bibliography will be shown in the bibliography section of the document, regardless of whether they were cited in the text of the document or not.

However, even with this change, only references that classify as either Standards, ISTQB® Documents, Books, and Articles and Web Pages will be typeset, see https://github.com/danopolan/istqb_latex/issues/34#issuecomment-1642097600. If desirable, we can add to bibliography a new subsection Other, where all the other references would appear. This may not be desirable in the final document, but it may help with checking that all the references are shown and correctly classified.