### PR TITLE
Add Copyright Notice

### DIFF
--- a/example-copyright.md
+++ b/example-copyright.md
@@ -1,0 +1,28 @@
+# Copyright Notice {-}
+
+Copyright Notice © International Software Testing Qualifications Board (hereinafter called ISTQB®).
+
+ISTQB® is a registered trademark of the International Software Testing Qualifications Board.
+
+Copyright © 2023 the authors of the Foundation Level v4.0 syllabus: Renzo Cerquozzi, Wim Decoutere, Klaudia Dussa-Zieger, Jean-François Riverin, Arnika Hryszko, Martin Klonk, Michaël Pilaeten, Meile Posthuma, Stuart Reid, Eric Riou du Cosquer (chair), Adam Roman, Lucjan Stapp, Stephanie Ulrich (vice chair), Eshraka Zakaria.
+
+Copyright © 2019 the authors for the update 2019 Klaus Olsen (chair), Meile Posthuma and Stephanie Ulrich.
+
+Copyright © 2018 the authors for the update 2018 Klaus Olsen (chair), Tauhida Parveen (vice chair), Rex Black (project manager), Debra Friedenberg, Matthias Hamburg, Judy McKay, Meile Posthuma, Hans Schaefer, Radoslaw Smilgin, Mike Smith, Steve Toms, Stephanie Ulrich, Marie Walsh, and Eshraka Zakaria.
+
+Copyright © 2011 the authors for the update 2011 Thomas Müller (chair), Debra Friedenberg, and the ISTQB WG Foundation Level.
+
+Copyright © 2010 the authors for the update 2010 Thomas Müller (chair), Armin Beer, Martin Klonk, and Rahul Verma.
+
+Copyright © 2007 the authors for the update 2007 Thomas Müller (chair), Dorothy Graham, Debra Friedenberg and Erik van Veenendaal.
+
+Copyright © 2005 the authors Thomas Müller (chair), Rex Black, Sigrid Eldh, Dorothy Graham, Klaus Olsen, Maaret Pyhäjärvi, Geoff Thompson, and Erik van Veenendaal.
+
+All rights reserved. The authors hereby transfer the copyright to the ISTQB®. The authors (as current copyright holders) and ISTQB® (as the future copyright holder) have agreed to the following conditions of use: 
+
+- Extracts, for non-commercial use, from this document may be copied if the source is acknowledged. Any Accredited Training Provider may use this syllabus as the basis for a training course if the  authors and the ISTQB® are acknowledged as the source and copyright owners of the syllabus and provided that any advertisement of such a training course may mention the syllabus only after official 
+accreditation of the training materials has been received from an ISTQB®-recognized Member Board.
+- Any individual or group of individuals may use this syllabus as the basis for articles and books, if the authors and the ISTQB® are acknowledged as the source and copyright owners of the syllabus.
+- Any other use of this syllabus is prohibited without first obtaining the approval in writing of the ISTQB®.
+- Any ISTQB®-recognized Member Board may translate this syllabus provided they reproduce the 
+abovementioned Copyright Notice in the translated version of the syllabus.

--- a/example.tex
+++ b/example.tex
@@ -13,6 +13,9 @@
 % Landing Page
 \istqblandingpage
 
+% Copyright Notice
+\markdownInput{./example-copyright.md}
+
 % Table of Contents
 \tableofcontents
 

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -117,8 +117,24 @@
         \markdownSetup
           {
             rendererPrototypes = {
-              %% Learning objectives
               attributeClassName = {
+                %% Unnumbered sections
+                \tl_if_eq:nnT
+                  { ##1 }
+                  { unnumbered }
+                  {
+                    \markdownSetup
+                      {
+                        rendererPrototypes = {
+                          headingOne = {
+                            \section * { ####1 }
+                            \addcontentsline { toc } { section } { ####1 }
+                            \markboth { ####1 } { ####1 }
+                          },
+                        }
+                      }
+                  }
+                %% Learning objectives
                 \tl_if_eq:nnT
                   { ##1 }
                   { learning-objectives }


### PR DESCRIPTION
Closes #28. I added an example of the copyright notice section to example.tex:

``` md
# Copyright Notice {-}

Copyright Notice © International Software Testing Qualifications Board (hereinafter called ISTQB®).

ISTQB® is a registered trademark of the International Software Testing Qualifications Board.

...
```

Here, `{-}` is a standard shorthand for `{.unnumbered}`. The following output is produced:

![copyright-notice](https://github.com/danopolan/istqb_latex/assets/603082/1c7f3efc-a897-45df-8903-3332aa33c317)

In atlas.tex, I added a commented-out line:

https://github.com/danopolan/istqb_latex/blob/c401f5502a2fdec4375171b75dd55285400caddb/atlas.tex#L15-L16

I commented the line out, because I don't have the required file md/00-copyright.md for ATLaS at the moment and including non-existing documents will crash the CI. After you have added 00-copyright.md to md/, you can uncomment the line in atlas.tex.