### PR TITLE
Add Revision History

### DIFF
--- a/example-copyright.md
+++ b/example-copyright.md
@@ -18,11 +18,10 @@ Copyright © 2007 the authors for the update 2007 Thomas Müller (chair), Doroth
 
 Copyright © 2005 the authors Thomas Müller (chair), Rex Black, Sigrid Eldh, Dorothy Graham, Klaus Olsen, Maaret Pyhäjärvi, Geoff Thompson, and Erik van Veenendaal.
 
-All rights reserved. The authors hereby transfer the copyright to the ISTQB®. The authors (as current copyright holders) and ISTQB® (as the future copyright holder) have agreed to the following conditions of use: 
+All rights reserved. The authors hereby transfer the copyright to the ISTQB®. The authors (as current copyright holders) and ISTQB® (as the future copyright holder) have agreed to the following conditions of use:
 
-- Extracts, for non-commercial use, from this document may be copied if the source is acknowledged. Any Accredited Training Provider may use this syllabus as the basis for a training course if the  authors and the ISTQB® are acknowledged as the source and copyright owners of the syllabus and provided that any advertisement of such a training course may mention the syllabus only after official 
-accreditation of the training materials has been received from an ISTQB®-recognized Member Board.
+- Extracts, for non-commercial use, from this document may be copied if the source is acknowledged. Any Accredited Training Provider may use this syllabus as the basis for a training course if the  authors and the ISTQB® are acknowledged as the source and copyright owners of the syllabus and provided that any advertisement of such a training course may mention the syllabus only after official accreditation of the training materials has been received from an ISTQB®-recognized Member Board.
 - Any individual or group of individuals may use this syllabus as the basis for articles and books, if the authors and the ISTQB® are acknowledged as the source and copyright owners of the syllabus.
 - Any other use of this syllabus is prohibited without first obtaining the approval in writing of the ISTQB®.
-- Any ISTQB®-recognized Member Board may translate this syllabus provided they reproduce the 
+- Any ISTQB®-recognized Member Board may translate this syllabus provided they reproduce the
 abovementioned Copyright Notice in the translated version of the syllabus.

--- a/example-revisions.md
+++ b/example-revisions.md
@@ -1,0 +1,14 @@
+# Revision History {- .revision-history}
+
+| Version | Date | Remarks |
+|---------|------|---------|
+CTFL v4.0 | 21.04.2023 | CTFL v4.0 -- General release version
+CTFL v3.1.1 | 01.07.2021 | CTFL v3.1.1 -- Copyright and logo update
+CTFL v3.1 | 11.11.2019 | CTFL v3.1 -- Maintenance release with minor updates
+ISTQB 2018 | 27.04.2018 | CTFL v3.0 -- Candidate general release version
+ISTQB 2011 | 01.04.2011 | CTFL Syllabus Maintenance Release
+ISTQB 2010 | 30.03.2010 | CTFL Syllabus Maintenance Release
+ISTQB 2007 | 01.05.2007 | CTFL Syllabus Maintenance Release
+ISTQB 2005 | 01.07.2005 | Certified Tester Foundation Level Syllabus v1.0
+ASQF V2.2 | 07.2003 | ASQF Syllabus Foundation Level Version v2.2 ``Lehrplan Grundlagen des Software-testens''
+ISEB V2.0 | 25.02.1999 | ISEB Software Testing Foundation Syllabus v2.0

--- a/example.tex
+++ b/example.tex
@@ -16,6 +16,9 @@
 % Copyright Notice
 \markdownInput{./example-copyright.md}
 
+% Revision History
+\markdownInput{./example-revisions.md}
+
 % Table of Contents
 \tableofcontents
 

--- a/istqb.cls
+++ b/istqb.cls
@@ -359,3 +359,16 @@
 % Hyperlinks
 \PassOptionsToPackage{hidelinks}{hyperref}
 \RequirePackage{hyperref}
+
+% Revision History
+\RequirePackage{tabularx, array}
+\RequirePackage{xcolor, colortbl}
+\definecolor{istqbrevisionhistoryheader}{HTML}{D9D9D9}
+\long\def\beginistqbrevisionhistory#1\endistqbrevisionhistory{%
+  \leavevmode \kern 0.08in\relax % Indent the table
+  \renewcommand{\arraystretch}{1.5}% Increase line spread
+  \begin{tabularx}\linewidth{|l|l|X|}\hline
+  \rowcolor{istqbrevisionhistoryheader}
+  #1%
+  \end{tabularx}%
+}

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -134,6 +134,92 @@
                         }
                       }
                   }
+                %% Revision history
+                \tl_if_eq:nnT
+                  { ##1 }
+                  { revision-history }
+                  {
+                    \group_begin:
+                    \def \markdownLaTeXTopRule { }
+                    \def \markdownLaTeXMidRule { }
+                    \def \markdownLaTeXBottomRule { }
+                    \def \markdownLaTeXRenderTableRow ####1
+                      {
+                        \markdownLaTeXColumnCounter = 0
+                        \ifnum \markdownLaTeXRowCounter = 0 \relax
+                          \markdownLaTeXReadAlignments ####1
+                          \markdownLaTeXTable = \expandafter \expandafter \expandafter {
+                            \expandafter \the \expandafter \markdownLaTeXTable \expandafter {
+                              \the \markdownLaTeXTableAlignment } }
+                          \addto@hook
+                            \markdownLaTeXTable
+                            {
+                              \markdownLaTeXTopRule
+                            }
+                        \else
+                          \markdownLaTeXRenderTableCell ####1
+                        \fi
+                        \ifnum \markdownLaTeXRowCounter = 1 \relax
+                          \addto@hook
+                            \markdownLaTeXTable
+                            \markdownLaTeXMidRule
+                        \fi
+                        \advance \markdownLaTeXRowCounter by 1 \relax
+                        \ifnum \markdownLaTeXRowCounter > \markdownLaTeXRowTotal \relax
+                          \addto@hook
+                            \markdownLaTeXTable
+                            {
+                              \markdownLaTeXBottomRule
+                              \endistqbrevisionhistory
+                            }
+                          \the \markdownLaTeXTable
+                          \expandafter \@gobble
+                        \fi \markdownLaTeXRenderTableRow
+                      }
+                    \def \markdownLaTeXReadAlignments ####1
+                      {
+                        \advance \markdownLaTeXColumnCounter by 1 \relax
+                        % Ignore alignment information, since the alignment in revision history is predetermined.
+                        \ifnum\markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax \else
+                          \expandafter \@gobble
+                        \fi \markdownLaTeXReadAlignments
+                      }
+                    \def \markdownLaTeXRenderTableCell ####1
+                      {
+                        \advance \markdownLaTeXColumnCounter by 1 \relax
+                        \ifnum \markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax
+                          \addto@hook
+                            \markdownLaTeXTable
+                            { ####1 & }
+                        \else
+                          \addto@hook
+                            \markdownLaTeXTable
+                            { ####1 \\ \hline }
+                          \expandafter \@gobble
+                        \fi \markdownLaTeXRenderTableCell
+                      }
+                    \markdownSetup
+                      {
+                        rendererPrototypes = {
+                          table = {
+                            \markdownLaTeXTable = { }
+                            \markdownLaTeXTableAlignment = { }
+                            \addto@hook
+                              \markdownLaTeXTable
+                              {
+                                \beginistqbrevisionhistory
+                              }
+                            \markdownLaTeXRowCounter = 0
+                            \markdownLaTeXRowTotal = ####2
+                            \markdownLaTeXColumnTotal = ####3
+                            \markdownLaTeXRenderTableRow
+                          },
+                          headerAttributeContextEnd = {
+                            \group_end:
+                          },
+                        }
+                      }
+                  }
                 %% Learning objectives
                 \tl_if_eq:nnT
                   { ##1 }

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -7,6 +7,7 @@
 
 % Hybrid Markdown + LaTeX text
 \markdownSetup{
+  fencedCode,
   rawAttribute,
 }
 


### PR DESCRIPTION
Closes #27. I added an example of the revision history section to example.tex:

``` md
# Revision History {- .revision-history}

| Version | Date | Remarks |
|---------|------|---------|
CTFL v4.0 | 21.04.2023 | CTFL v4.0 -- General release version
CTFL v3.1.1 | 01.07.2021 | CTFL v3.1.1 -- Copyright and logo update
CTFL v3.1 | 11.11.2019 | CTFL v3.1 -- Maintenance release with minor updates
ISTQB 2018 | 27.04.2018 | CTFL v3.0 -- Candidate general release version
ISTQB 2011 | 01.04.2011 | CTFL Syllabus Maintenance Release
ISTQB 2010 | 30.03.2010 | CTFL Syllabus Maintenance Release
ISTQB 2007 | 01.05.2007 | CTFL Syllabus Maintenance Release
ISTQB 2005 | 01.07.2005 | Certified Tester Foundation Level Syllabus v1.0
ASQF V2.2 | 07.2003 | ASQF Syllabus Foundation Level Version v2.2 ``Lehrplan Grundlagen des Software-testens''
ISEB V2.0 | 25.02.1999 | ISEB Software Testing Foundation Syllabus v2.0
```

![revision-history](https://github.com/danopolan/istqb_latex/assets/603082/40dc198a-b1ad-41ac-866e-01fb31f2e64a)