### PR TITLE
Add Appendices

### DIFF
--- a/istqb.cls
+++ b/istqb.cls
@@ -347,6 +347,19 @@
   \par\kern -0.2in
 }
 
+%% Appendices
+\newcounter{istqbappendix}
+\newenvironment{istqbappendices}{%
+  \begingroup
+  \let\istqboldsection\section
+  \def\section##1{%
+    \stepcounter{istqbappendix}%
+    \istqboldsection{Appendix~\Alph{istqbappendix}~--~##1}}%
+}{%
+  \setcounter{istqbappendix}{0}%
+  \endgroup
+}
+
 % Index
 \RequirePackage{imakeidx}
 \makeindex[columns=2, columnsep=1cm, noautomatic]

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -140,7 +140,6 @@
                   { learning-objectives }
                   {
                     \group_begin:
-                    \begin { istqb objectives }
                     \markdownSetup
                       {
                         rendererPrototypes = {
@@ -179,8 +178,8 @@
                                     \next
                                   },
                                   olEnd = {
-                                    \group_end:
                                     \end { istqb objectives }
+                                    \group_end:
                                   },
                                 }
                               }
@@ -190,6 +189,7 @@
                           },
                         }
                       }
+                    \begin { istqb objectives }
                   }
               },
               attributeIdentifier = {


### PR DESCRIPTION
Closes #31.

To add appendices to ATLaS, add the following code to `atlas.tex` in #33 after `\printistqbbibliography`:

``` tex
% Appendices
\begin{istqbappendices}
\markdownInput{md/A-cognitive-levels-of-knowledge.md}
\end{istqbappendices}
```