### PR TITLE
Fix bibliography formatting

### DIFF
--- a/istqb.cls
+++ b/istqb.cls
@@ -191,6 +191,7 @@
   \fontsize{14}{16.8}\selectfont
   #1%
 }
+\urlstyle{same}
 \setlength\bibitemsep{0.5\baselineskip}
 
 %% Entry type filters

--- a/istqb.cls
+++ b/istqb.cls
@@ -191,6 +191,7 @@
   \fontsize{14}{16.8}\selectfont
   #1%
 }
+\setlength\bibitemsep{0.5\baselineskip}
 
 %% Entry type filters
 \defbibfilter{standards}{type=report}


### PR DESCRIPTION
Closes https://github.com/danopolan/istqb_latex/issues/49 by adding an extra space between references and by using the same font for URLs as for the body text:

![image](https://github.com/danopolan/istqb_latex/assets/603082/4e37e17d-49dd-468f-8499-062a59ebea82)