### PR TITLE
Add List of Tables/Figures to Table of Contents

### DIFF
--- a/istqb.cls
+++ b/istqb.cls
@@ -142,7 +142,7 @@
     \vbox_gset:NV
       \l_istqb_footer_box
       \g_istqb_footer_tl
-    % Ensure that the footer is always the 0.8in from the bottom of the page regardless of its contents.
+    %%%% Ensure that the footer is always the 0.8in from the bottom of the page regardless of its contents.
     \tl_new:N \l_istqb_geometry_tl
     \tl_gset:NV
       \l_istqb_geometry_tl
@@ -363,9 +363,9 @@
 % Index
 \RequirePackage{imakeidx}
 \makeindex[columns=2, columnsep=1cm, noautomatic]
-% Ensure that the index is numbered and part of the table of contents.
+%% Ensure that the index is numbered and part of the table of contents.
 \renewcommand\imki@indexlevel{\section}
-% Remove spaces between indexed items.
+%% Remove spaces between indexed items.
 \RequirePackage{etoolbox}
 \apptocmd\theindex{\let\indexspace=\relax}{}{\PatchFailed}
 

--- a/istqb.cls
+++ b/istqb.cls
@@ -278,6 +278,7 @@
     \normalfont
     \bfseries
     \fontsize{16}{19.2}\selectfont
+    \phantomsection
     \begingroup
     \titlelabel{\thetitle\kern0.3em}
     #1%
@@ -298,6 +299,7 @@
     \normalfont
     \mdseries
     \fontsize{14}{16.8}\selectfont
+    \phantomsection
     \begingroup
     \titlelabel{\thetitle\kern0.3em}
     #1%

--- a/istqb.cls
+++ b/istqb.cls
@@ -173,9 +173,9 @@
 \floatplacement{table}{H}
 
 % Lists of Tables and Figures
-\RequirePackage{etoolbox}
-\pretocmd{\listoffigures}{\clearpage}{}{}  % Ensure List of Figures starts on a new page.
-\pretocmd{\listoftables}{\clearpage}{}{}  % Ensure List of Tables starts on a new page.
+%% Place lists into the Table of Contents.
+\PassOptionsToPackage{nottoc}{tocbibind}
+\RequirePackage{tocbibind}
 
 % Table of Contents
 \setcounter{tocdepth}{3}  % Show level 1 up to level 3 of headings.

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -321,8 +321,8 @@
 \renewcommand
   \markdownLaTeXRendererDirectOrIndirectLink[4]
   {
-    % If the URL begins with a hash sign, then we assume that it is a relative
-    % reference. Otherwise, we assume that it is an absolute URL.
+    %% If the URL begins with a hash sign, then we assume that it is a relative
+    %% reference. Otherwise, we assume that it is an absolute URL.
     \tl_set:Nn
       \l_tmpa_tl
       { #3 }
@@ -370,8 +370,8 @@
 \renewcommand
   \markdownLaTeXRendererAutolink[2]
   {
-    % If the URL begins with a hash sign, then we assume that it is a relative
-    % reference. Otherwise, we assume that it is an absolute URL.
+    %% If the URL begins with a hash sign, then we assume that it is a relative
+    %% reference. Otherwise, we assume that it is an absolute URL.
     \tl_set:Nn
       \l_tmpa_tl
       { #2 }

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -129,8 +129,8 @@
                         rendererPrototypes = {
                           headingOne = {
                             \section * { ####1 }
-                            \addcontentsline { toc } { section } { ####1 }
                             \markboth { ####1 } { ####1 }
+                            \addcontentsline { toc } { section } { ####1 }
                           },
                         }
                       }


### PR DESCRIPTION
Closes https://github.com/danopolan/istqb_latex/issues/47 by adding the List of Tables and the List of Figures to the Table of Contents as unnumbered sections:

![image](https://github.com/danopolan/istqb_latex/assets/603082/19b43548-00d2-46b0-8c9c-6775d6ee0175)

