### PR TITLE
Add section Further Reading with spillover bibliography

### DIFF
--- a/example-istqb-content.md
+++ b/example-istqb-content.md
@@ -38,7 +38,7 @@ Section references with custom text:
 
 - You can add link to the section with custom text like this [testing principles](#section:seven-testing-principles). And it doesn't matter if the section is in this or any other MD document.
 
-For more information, see the documentation of the Markdown package for \TeX [@novotny:2017].
+For more information, see the documentation of the Markdown package for \TeX{} referenced in section *Further Reading* at the end of this document.
 
 ### Figures
 

--- a/example.bib
+++ b/example.bib
@@ -47,7 +47,7 @@
   pages = {82-89}
 }
 
-% Web pages
+% Further Reading
 @online{kime:2023,
   author = {Philip Kime},
   title = {Bib\LaTeX},
@@ -63,5 +63,5 @@
   title = {Exploration through Example},
   date = {2003-08-21},
   url = {http://www.exampler.com/old-blog/2003/08/21/},
-  urldate = {2023-07-11},
+  urldate = {2023-07-11}
 }

--- a/istqb.cls
+++ b/istqb.cls
@@ -185,12 +185,6 @@
 \RequirePackage{csquotes}
 \PassOptionsToPackage{style=iso-authoryear}{biblatex}
 \RequirePackage{biblatex}
-\defbibheading{bibliography}[Bibliography]{%
-  \normalfont
-  \mdseries
-  \fontsize{14}{16.8}\selectfont
-  #1%
-}
 \urlstyle{same}
 \setlength\bibitemsep{0.5\baselineskip}
 
@@ -198,16 +192,29 @@
 \defbibfilter{standards}{type=report}
 \defbibfilter{istqb-documents}{type=misc and keyword=istqb}
 \defbibfilter{books}{type=book}
-\defbibfilter{articles-and-web-pages}{type=article or type=online}
+\defbibfilter{articles}{type=article}
+\defbibfilter{further-reading}{not ( type=report or ( type=misc and keyword=istqb ) or type=book or type=article )}
 
 %% Reference printing
 \newcommand\printistqbbibliography{%
   \clearpage
-  \section{References}
-  \printbibliography[filter=standards, title=Standards]
-  \printbibliography[filter=istqb-documents, title=ISTQB\textsuperscript{\textregistered} Documents]
-  \printbibliography[filter=books, title=Books]
-  \printbibliography[filter=articles-and-web-pages, title=Articles and Web Pages]
+  \section{References}%
+  \begingroup
+  \defbibheading{bibliography}{%
+    \normalfont
+    \mdseries
+    \fontsize{14}{16.8}\selectfont
+    ##1%
+  }%
+  \printbibliography[filter=standards, title=Standards]%
+  \printbibliography[filter=istqb-documents, title=ISTQB\textsuperscript{\textregistered} Documents]%
+  \printbibliography[filter=books, title=Books]%
+  \printbibliography[filter=articles, title=Articles]%
+  \endgroup
+  \begingroup
+  \defbibheading{bibliography}{\section{##1}}%
+  \printbibliography[filter=further-reading, title=Further Reading]%
+  \endgroup
 }
 
 % Landing Page

--- a/istqb.cls
+++ b/istqb.cls
@@ -183,17 +183,21 @@
 
 % Bibliography
 \RequirePackage{csquotes}
-\PassOptionsToPackage{style=iso-authoryear}{biblatex}
+\PassOptionsToPackage{style=iso-authoryear, citetracker=true}{biblatex}
 \RequirePackage{biblatex}
 \urlstyle{same}
 \setlength\bibitemsep{0.5\baselineskip}
 
-%% Entry type filters
-\defbibfilter{standards}{type=report}
-\defbibfilter{istqb-documents}{type=misc and keyword=istqb}
-\defbibfilter{books}{type=book}
-\defbibfilter{articles}{type=article}
-\defbibfilter{further-reading}{not ( type=report or ( type=misc and keyword=istqb ) or type=book or type=article )}
+%% Bibliographic categories
+\DeclareBibliographyCategory{uncited}
+\AtEveryBibitem{\ifciteseen{}{\addtocategory{uncited}{\thefield{entrykey}}}}
+
+%% Bibliographic filters
+\defbibfilter{standards}{type=report and not category=uncited}
+\defbibfilter{istqb-documents}{type=misc and keyword=istqb and not category=uncited}
+\defbibfilter{books}{type=book and not category=uncited}
+\defbibfilter{articles}{type=article and not category=uncited}
+\defbibfilter{further-reading}{not ( type=report or ( type=misc and keyword=istqb ) or type=book or type=article ) or category=uncited}
 
 %% Reference printing
 \newcommand\printistqbbibliography{%


### PR DESCRIPTION
Closes https://github.com/danopolan/istqb_latex/issues/48 by changing subsection *Articles and Web Pages* to *Articles* and bz adding section *Further Reading* that shows references that did not fit any subsections of section *References*:

![image](https://github.com/danopolan/istqb_latex/assets/603082/365ff2f1-9ab0-4338-973e-584d8a26c7e4)
![image](https://github.com/danopolan/istqb_latex/assets/603082/3e05f1fa-4d6d-4603-bf5f-1603d214bc36)