### PR TITLE
Fix table formatting

### DIFF
--- a/example-istqb-content.md
+++ b/example-istqb-content.md
@@ -52,11 +52,11 @@ You can reference the image from the text of the document as follows: <#figure:e
 
 Here is an example table:
 
- | Right | Left | Default | Center |
- |------:|:-----|---------|:------:|
- |   12  |  12  |    12   |    12  |
- |  123  |  123 |   123   |   123  |
- |    1  |  1   |   1     |     1  |
+ | Right | Left | Center | Default |
+ |------:|:-----|:------:|---------|
+ |   12  |  12  |    12  |    12   |
+ |  123  |  123 |   123  |   123   |
+ |    1  |  1   |     1  |   1     |
 
  : Here is a caption describing the table. \label{table:label}
 

--- a/istqb.cls
+++ b/istqb.cls
@@ -377,15 +377,20 @@
 \PassOptionsToPackage{hidelinks}{hyperref}
 \RequirePackage{hyperref}
 
-% Revision History
+% Tables
 \RequirePackage{tabularx, array}
 \RequirePackage{xcolor, colortbl}
-\definecolor{istqbrevisionhistoryheader}{HTML}{D9D9D9}
-\long\def\beginistqbrevisionhistory#1\endistqbrevisionhistory{%
+\definecolor{istqbtableheader}{HTML}{D9D9D9}
+\long\def\beginistqbtable#1#2\endistqbtable{%
   \leavevmode \kern 0.08in\relax % Indent the table
   \renewcommand{\arraystretch}{1.5}% Increase line spread
-  \begin{tabularx}\linewidth{|l|l|X|}\hline
-  \rowcolor{istqbrevisionhistoryheader}
-  #1%
+  \begin{tabularx}\linewidth{#1}\hline
+  \rowcolor{istqbtableheader}
+  #2%
   \end{tabularx}%
+}
+
+%% Revision History
+\long\def\beginistqbrevisionhistory#1\endistqbrevisionhistory{%
+  \beginistqbtable{|l|l|X|}#1\endistqbtable
 }

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -141,9 +141,6 @@
                   { revision-history }
                   {
                     \group_begin:
-                    \def \markdownLaTeXTopRule { }
-                    \def \markdownLaTeXMidRule { }
-                    \def \markdownLaTeXBottomRule { }
                     \def \markdownLaTeXRenderTableRow ####1
                       {
                         \markdownLaTeXColumnCounter = 0
@@ -152,27 +149,14 @@
                           \markdownLaTeXTable = \expandafter \expandafter \expandafter {
                             \expandafter \the \expandafter \markdownLaTeXTable \expandafter {
                               \the \markdownLaTeXTableAlignment } }
-                          \addto@hook
-                            \markdownLaTeXTable
-                            {
-                              \markdownLaTeXTopRule
-                            }
                         \else
                           \markdownLaTeXRenderTableCell ####1
-                        \fi
-                        \ifnum \markdownLaTeXRowCounter = 1 \relax
-                          \addto@hook
-                            \markdownLaTeXTable
-                            \markdownLaTeXMidRule
                         \fi
                         \advance \markdownLaTeXRowCounter by 1 \relax
                         \ifnum \markdownLaTeXRowCounter > \markdownLaTeXRowTotal \relax
                           \addto@hook
                             \markdownLaTeXTable
-                            {
-                              \markdownLaTeXBottomRule
-                              \endistqbrevisionhistory
-                            }
+                            \endistqbrevisionhistory
                           \the \markdownLaTeXTable
                           \expandafter \@gobble
                         \fi \markdownLaTeXRenderTableRow
@@ -184,20 +168,6 @@
                         \ifnum\markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax \else
                           \expandafter \@gobble
                         \fi \markdownLaTeXReadAlignments
-                      }
-                    \def \markdownLaTeXRenderTableCell ####1
-                      {
-                        \advance \markdownLaTeXColumnCounter by 1 \relax
-                        \ifnum \markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax
-                          \addto@hook
-                            \markdownLaTeXTable
-                            { ####1 & }
-                        \else
-                          \addto@hook
-                            \markdownLaTeXTable
-                            { ####1 \\ \hline }
-                          \expandafter \@gobble
-                        \fi \markdownLaTeXRenderTableCell
                       }
                     \markdownSetup
                       {
@@ -304,11 +274,89 @@
   }
 
 % Tables
-\RequirePackage{booktabs}
 \markdownSetup
   {
     pipeTables,
     tableCaptions,
+  }
+\def \markdownLaTeXRenderTableRow #1
+  {
+    \markdownLaTeXColumnCounter = 0
+    \ifnum \markdownLaTeXRowCounter = 0 \relax
+      \markdownLaTeXReadAlignments #1
+      \markdownLaTeXTable = \expandafter \expandafter \expandafter {
+        \expandafter \the \expandafter \markdownLaTeXTable \expandafter {
+          \the \markdownLaTeXTableAlignment } }
+    \else
+      \markdownLaTeXRenderTableCell #1
+    \fi
+    \advance \markdownLaTeXRowCounter by 1 \relax
+    \ifnum \markdownLaTeXRowCounter > \markdownLaTeXRowTotal \relax
+      \markdownLaTeXTable = \expandafter \expandafter \expandafter {
+        \expandafter \the \expandafter \markdownLaTeXTable
+          \the \markdownLaTeXTableEnd }
+      \the \markdownLaTeXTable
+      \expandafter \@gobble
+    \fi \markdownLaTeXRenderTableRow
+  }
+\def \markdownLaTeXReadAlignments #1
+  {
+    \advance \markdownLaTeXColumnCounter by 1 \relax
+    \if #1 d
+      \addto@hook \markdownLaTeXTableAlignment { X| }
+    \else
+      \addto@hook \markdownLaTeXTableAlignment { #1| }
+    \fi
+    \ifnum\markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax \else
+      \expandafter \@gobble
+    \fi \markdownLaTeXReadAlignments
+  }
+\def \markdownLaTeXRenderTableCell #1
+  {
+    \advance \markdownLaTeXColumnCounter by 1 \relax
+    \ifnum \markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax
+      \addto@hook
+        \markdownLaTeXTable
+        { #1 & }
+    \else
+      \addto@hook
+        \markdownLaTeXTable
+        { #1 \\ \hline }
+      \expandafter \@gobble
+    \fi \markdownLaTeXRenderTableCell
+  }
+\markdownSetup
+  {
+    rendererPrototypes = {
+      table = {
+        \markdownLaTeXTable = { }
+        \markdownLaTeXTableAlignment = { | }
+        \markdownLaTeXTableEnd = { \endistqbtable }
+        \tl_if_empty:nF
+          { #1 }
+          {
+            \addto@hook
+              \markdownLaTeXTable
+              {
+                \begin { table }
+                \centering
+              }
+            \addto@hook
+              \markdownLaTeXTableEnd
+              {
+                \caption { #1 }
+                \end { table }
+              }
+          }
+        \addto@hook
+          \markdownLaTeXTable
+          \beginistqbtable
+        \markdownLaTeXRowCounter = 0
+        \markdownLaTeXRowTotal = #2
+        \markdownLaTeXColumnTotal = #3
+        \markdownLaTeXRenderTableRow
+      },
+    }
   }
 
 % Relative references


### PR DESCRIPTION
Closes https://github.com/danopolan/istqb_latex/issues/46 by applying the formatting of Revision History to all markdown tables:

``` md
### Tables

Here is an example table:

 | Right | Left | Center | Default |
 |------:|:-----|:------:|---------|
 |   12  |  12  |    12  |    12   |
 |  123  |  123 |   123  |   123   |
 |    1  |  1   |     1  |   1     |

 : Here is a caption describing the table. \label{table:label}

You can reference the table from the text of the document as follows: <#table:label>.
```

 ![image](https://github.com/danopolan/istqb_latex/assets/603082/c2d54d77-8b0e-4476-86e6-247d157b1113)