### PR TITLE
Fix heading alignment

### DIFF
--- a/istqb.cls
+++ b/istqb.cls
@@ -271,11 +271,11 @@
     linewidth=0.95pt,
     linecolor=black,
     innerleftmargin=0.08in,
-    innerrightmargin=0.08in,
+    innerrightmargin=0.2in,
     innertopmargin=0.05in,
     innerbottommargin=0in,
-    leftmargin=0.06in,
-    rightmargin=-0.1in,
+    leftmargin=0in,
+    rightmargin=0in,
   ]%
     \normalfont
     \bfseries
@@ -292,11 +292,11 @@
     linewidth=0.63pt,
     linecolor=black,
     innerleftmargin=0.08in,
-    innerrightmargin=0.08in,
+    innerrightmargin=0.2in,
     innertopmargin=0.035in,
     innerbottommargin=0in,
-    leftmargin=0.06in,
-    rightmargin=-0.1in,
+    leftmargin=0in,
+    rightmargin=0in,
   ]%
     \normalfont
     \mdseries


### PR DESCRIPTION
Closes https://github.com/danopolan/istqb_latex/issues/45 by aligning section and subsection headings with left/right margins and preventing overfull lines:

![image](https://github.com/danopolan/istqb_latex/assets/603082/9f4d0d14-0003-44d7-bf97-9d5f25a7cf94)