### PR TITLE
Add document type to YAML metadata

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,6 +1,7 @@
 schema: Certified Tester
 level: Foundation Level
 code: example
+type: Syllabus
 version: Version 2018 V3.1
 date: 11 November 2019
 release: For public release

--- a/istqb.cls
+++ b/istqb.cls
@@ -214,6 +214,7 @@
 \ExplSyntaxOn
 \str_new:N \g_istqb_title_str
 \str_new:N \g_istqb_code_str
+\str_new:N \g_istqb_type_str
 \newcommand
   \istqblandingpage
   {
@@ -237,7 +238,7 @@
         \\
       }
     \g_istqb_level_str \\
-    Syllabus
+    \g_istqb_type_str
     \par \vfill
     \normalfont
     \itshape

--- a/markdownthemeistqb_syllabus.sty
+++ b/markdownthemeistqb_syllabus.sty
@@ -33,6 +33,11 @@
           \g_istqb_level_str
           { #1 }
       },
+      type = {
+        \str_gset:Nn
+          \g_istqb_type_str
+          { #1 }
+      },
       title = {
         \str_gset:Nn
           \g_istqb_title_str

--- a/md/metadata.yml
+++ b/md/metadata.yml
@@ -2,6 +2,7 @@ schema: Certified Tester
 level: Advanced Level
 title: Agile Test Leadership at Scale
 code: CTAL-ATLaS
+type: Syllabus
 version: v2.0
 date: 11 May 2023
 release: Beta


### PR DESCRIPTION
Closes https://github.com/danopolan/istqb_latex/issues/55. You will want to add `type: Body of Knowledge` to bok-md/metadata.yml in https://github.com/danopolan/istqb_latex/pull/38.